### PR TITLE
Add initial Playwright smoke test

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Homepage', () => {
+  test('loads and shows hero heading', async ({ page }) => {
+    await page.goto('/');                       // baseURL libre
+    const h1 = page.getByRole('heading', { level: 1 });
+    await expect(h1).toHaveText(/funkspace/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add e2e folder with a home page smoke test checking for the hero heading

## Testing
- `pnpm install`
- `pnpm exec playwright test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_686be44df550832081076d5669c6be63