### PR TITLE
Fix Vitest e2e interference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 node_modules
+coverage/

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
 import { resolve } from "node:path";
 
@@ -30,5 +30,6 @@ export default defineConfig({
         perFile: false,
       },
     },
+    exclude: [...configDefaults.exclude, 'e2e/**'],
   },
 });


### PR DESCRIPTION
## Summary
- prevent Playwright tests from being collected by Vitest
- ignore coverage reports

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686be6f397c4832084a8108f6f363839