### PR TITLE
Adjust Vitest coverage behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,18 @@
 - The backend is a Slack-compatible API built in Next.js 🚀
 
 # FunkSpace App
+
+## Tests
+
+Run unit tests without collecting coverage:
+
+```bash
+pnpm test
+```
+
+Generate a coverage report (used in CI):
+
+```bash
+pnpm coverage
+```
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "lint": "pnpm --filter frontend exec next lint --max-warnings=0 && prettier --check .",
-    "test": "vitest run --coverage",
+    "test": "vitest run",
+    "coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     setupFiles: "./vitest.setup.ts",
     css: true,
     coverage: {
-      enabled: true,
+      enabled: Boolean(process.env.CI),
       provider: "v8",
       include: ["src/**/*.{ts,tsx}"],
       reporter: ["text", "html"],


### PR DESCRIPTION
## Summary
- collect coverage only in CI
- expose `pnpm coverage` script
- document local/CI test steps

## Testing
- `pnpm test`
- `pnpm coverage`


------
https://chatgpt.com/codex/tasks/task_e_686be89f23c8832098b20642e2905c08