### PR TITLE
Improve Playwright download reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,33 @@ Generate a coverage report (used in CI):
 ```bash
 pnpm coverage
 ```
+
+## Playwright browser downloads
+
+End-to-end tests use Playwright with only the Chromium browser. The `postinstall`
+script installs this browser under `node_modules` so it can be cached in CI:
+
+```bash
+pnpm install
+```
+
+If Playwright downloads fail due to network restrictions, point the installer at
+an allow-listed mirror before running `pnpm install`:
+
+```bash
+export PLAYWRIGHT_DOWNLOAD_HOST=https://playwright.azureedge.net
+```
+
+When running outside of CI, you can skip Firefox and WebKit downloads by
+installing only Chromium:
+
+```bash
+PLAYWRIGHT_BROWSERS_PATH=0 pnpm exec playwright install chromium --with-deps
+```
+
+If downloads remain impossible, use the official Docker image which already
+contains all browsers:
+
+```bash
+docker run --rm -it mcr.microsoft.com/playwright:v1.53.2-jammy
+```

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "test": "vitest run",
     "coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "e2e": "playwright test",
-    "e2e:ui": "playwright test --ui",
+    "e2e": "PLAYWRIGHT_BROWSERS_PATH=0 playwright test",
+    "e2e:ui": "PLAYWRIGHT_BROWSERS_PATH=0 playwright test --ui",
     "e2e:report": "playwright show-report",
-    "postinstall": "playwright install --with-deps"
+    "postinstall": "PLAYWRIGHT_BROWSERS_PATH=0 playwright install chromium --with-deps"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.2",


### PR DESCRIPTION
## Summary
- install only the Chromium browser in postinstall
- run Playwright tests with the local browser cache
- document how to use a download mirror and fallback Docker image

## Testing
- `pnpm test`
- `pnpm run e2e` *(fails: browser or fonts blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686bed80b57c8320af80cce138ee45ae