### PR TITLE
Fix Playwright install on Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ pnpm coverage
 ## Playwright browser downloads
 
 End-to-end tests use Playwright with only the Chromium browser. The `postinstall`
-script installs this browser under `node_modules` so it can be cached in CI:
+script installs this browser under `node_modules` so it can be cached in CI. On
+Vercel the installation is skipped automatically:
 
 ```bash
 pnpm install

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "e2e": "cross-env PLAYWRIGHT_BROWSERS_PATH=0 playwright test",
     "e2e:ui": "cross-env PLAYWRIGHT_BROWSERS_PATH=0 playwright test --ui",
     "e2e:report": "playwright show-report",
-    "postinstall": "cross-env PLAYWRIGHT_BROWSERS_PATH=0 playwright install chromium --with-deps",
+    "postinstall": "if [ \"$VERCEL\" != \"1\" ]; then cross-env PLAYWRIGHT_BROWSERS_PATH=0 playwright install chromium --with-deps; fi",
     "build": "pnpm -F frontend build"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- skip Playwright postinstall when Vercel builds
- document that the install step is skipped on Vercel

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686c169447988320b2d652b3227e3698