### PR TITLE
Fix Vercel build for Next.js project

### DIFF
--- a/.codex/smoke.sh
+++ b/.codex/smoke.sh
@@ -22,7 +22,7 @@ grep -q "Compiled successfully" /tmp/build.log
 
 # 3. Prod boot (10 s budget)
 (timeout 10 pnpm -F frontend start -p 4001 > /tmp/start.log 2>&1 || true)
-grep -q "started server on" /tmp/start.log   # SWC/Sandbox message
+grep -q "Ready in" /tmp/start.log   # confirm server started
 
 # 4. Lint
 pnpm -F frontend lint

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",
-    "build": "echo 'Compiled successfully'",
-    "start": "echo 'started server on'",
-    "lint": "echo 'lint ok'"
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
   },
   "dependencies": {
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary
- run real `next build`/`start`/`lint` commands in the frontend package
- expect `Ready in` log instead of `started server on` in smoke test

## Testing
- `bash .codex/smoke.sh`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686c22ed91c08320bb224e7e2fb9fa8f