### PR TITLE
Fix vercel build root mismatch

### DIFF
--- a/scripts/vercel-fix.sh
+++ b/scripts/vercel-fix.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+# ❶ guarantee a vercel.json with the correct rootDirectory
+jq -n '{rootDirectory:"frontend"}' > vercel.json
+
 # Step 1: Set Vercel project root to frontend (if vercel CLI available)
 if command -v vercel >/dev/null; then
   vercel project link --yes --cwd frontend || true
@@ -15,10 +18,10 @@ for config in frontend/next.config.js frontend/next.config.ts; do
   fi
 done
 
-# Step 2b: Purge overrides from vercel.json
+# Step 2b: Remove other overrides from vercel.json while keeping rootDirectory
 if [ -f vercel.json ]; then
   tmp=$(mktemp)
-  jq 'del(.buildCommand, .outputDirectory, .rootDirectory)' vercel.json > "$tmp" && mv "$tmp" vercel.json
+  jq 'del(.buildCommand, .outputDirectory)' vercel.json > "$tmp" && mv "$tmp" vercel.json
 fi
 
 # Step 3: Ensure Turborepo caches .next correctly
@@ -26,3 +29,8 @@ if [ -f turbo.json ]; then
   tmp=$(mktemp)
   jq '.pipeline.build.outputs |= (. // []) + [".next/**", "!**/.next/cache/**"] | unique' turbo.json > "$tmp" && mv "$tmp" turbo.json
 fi
+
+# ❷ after "next build" make sure the manifest exists (local safeguard)
+pnpm -F frontend build
+test -f frontend/.next/routes-manifest.json \
+  || { echo "routes-manifest missing – aborting"; exit 1; }


### PR DESCRIPTION
## Summary
- ensure `vercel.json` always sets `rootDirectory`
- clean overrides without deleting `rootDirectory`
- safeguard build: run `pnpm -F frontend build` and verify `routes-manifest`

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686c306f87188320b32f59ef7397a946