### PR TITLE
chore: optimize vercelignore

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,3 +1,15 @@
-e2e
-__tests__
-*.log
+# Ignore test sources and specs
+**/*.test.ts?(x)
+__tests__/
+e2e/
+playwright/**
+
+# Ignore storybook and coverage artefacts
+.storybook/
+coverage/
+
+# Ignore local documentation and markdown content
+*.md
+
+# Optional – Vitest raw output
+.vitest/


### PR DESCRIPTION
## Summary
- refine `.vercelignore` patterns to keep dev-only files from Vercel

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686cb37ff97483208289d8b280617e47